### PR TITLE
fix: kayıt istekleri endpoint'inin tüm durumları döndürmesini sağla

### DIFF
--- a/src/backend/apps/enrollments/services.py
+++ b/src/backend/apps/enrollments/services.py
@@ -66,11 +66,10 @@ class EnrollmentService:
         return kayit
 
     @staticmethod
-    def bekleyen_kayitlari_listele(akademisyen):
+    def kayit_isteklerini_listele(akademisyen):
         return DersKaydi.objects.filter(
             donem_dersi__akademisyen=akademisyen,
-            onay_durumu=DersKaydi.Durum.BEKLEMEDE,
-        ).select_related("ogrenci__user", "donem_dersi__ders")
+        ).select_related("ogrenci__user", "donem_dersi__ders").order_by("-id")
 
     @staticmethod
     def ders_kaydi_onayla(kayit_id, akademisyen):

--- a/src/backend/apps/enrollments/tests.py
+++ b/src/backend/apps/enrollments/tests.py
@@ -304,19 +304,19 @@ class EnrollmentServiceOnayTestleri(TemelKurulum):
         with self.assertRaises(PermissionDenied):
             EnrollmentService.ders_kaydi_reddet(self.kayit.pk, self.akademisyen2)
 
-    def test_bekleyen_kayitlar_listelendi(self):
-        bekleyenler = EnrollmentService.bekleyen_kayitlari_listele(self.akademisyen)
-        self.assertEqual(bekleyenler.count(), 1)
+    def test_tum_kayitlar_listelendi(self):
+        kayitlar = EnrollmentService.kayit_isteklerini_listele(self.akademisyen)
+        self.assertEqual(kayitlar.count(), 1)
 
-    def test_onaylanan_bekleyenlerde_gorunmez(self):
+    def test_onaylanan_kayit_listede_gorunur(self):
         self.kayit.onay_durumu = DersKaydi.Durum.ONAYLANDI
         self.kayit.save()
-        bekleyenler = EnrollmentService.bekleyen_kayitlari_listele(self.akademisyen)
-        self.assertEqual(bekleyenler.count(), 0)
+        kayitlar = EnrollmentService.kayit_isteklerini_listele(self.akademisyen)
+        self.assertEqual(kayitlar.count(), 1)
 
-    def test_baska_akademisyenin_bekleyenleri_gorunmez(self):
-        bekleyenler = EnrollmentService.bekleyen_kayitlari_listele(self.akademisyen2)
-        self.assertEqual(bekleyenler.count(), 0)
+    def test_baska_akademisyenin_kayitlari_gorunmez(self):
+        kayitlar = EnrollmentService.kayit_isteklerini_listele(self.akademisyen2)
+        self.assertEqual(kayitlar.count(), 0)
 
 
 class EnrollmentServiceTranskriptTestleri(TemelKurulum):

--- a/src/backend/apps/enrollments/views.py
+++ b/src/backend/apps/enrollments/views.py
@@ -164,20 +164,20 @@ class OgrenciDersKayitView(APIView):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-#  AKADEMİSYEN — bekleyen kayıt isteklerini listele
+#  AKADEMİSYEN — kayıt isteklerini listele
 #  GET /api/academician/enrollment-requests/
 # ─────────────────────────────────────────────────────────────────────────────
 
 class AkademisyenKayitIstekleriView(APIView):
     """
     GET /api/academician/enrollment-requests/
-    Akademisyenin derslerine ait bekleyen kayıt isteklerini döner.
+    Akademisyenin derslerine ait tüm kayıt isteklerini döner.
     """
     permission_classes = [IsAkademisyen]
 
     def get(self, request):
         akademisyen = request.user.akademisyen
-        kayitlar = EnrollmentService.bekleyen_kayitlari_listele(akademisyen)
+        kayitlar = EnrollmentService.kayit_isteklerini_listele(akademisyen)
         serializer = DersKaydiOkuSerializer(kayitlar, many=True)
         return Response(serializer.data)
 


### PR DESCRIPTION
## Sorun

`GET /api/academician/enrollment-requests/` endpoint'i yalnızca `beklemede` durumundaki kayıtları döndürüyordu. Onaylanan veya reddedilen kayıtlar response'a dahil edilmediği için frontend bu kayıtları gösteremiyordu.

## Yapılan Değişiklikler

- `bekleyen_kayitlari_listele` → `kayit_isteklerini_listele` olarak yeniden adlandırıldı
- `onay_durumu = BEKLEMEDE` filtresi kaldırıldı; endpoint artık tüm durumları döndürüyor
- Kayıtlar en yeniden eskiye sıralanıyor (`.order_by("-id")`)
- İlgili view, docstring ve testler güncellendi

## Sonuç

Endpoint artık `beklemede`, `onaylandi` ve `reddedildi` durumundaki tüm kayıtları döndürüyor. Frontend `onay_durumu` alanına göre filtreleme yapabilir.