### PR TITLE
feat: DonemDersiOkuSerializer'a ogrenci_sayisi alanı ekle

### DIFF
--- a/src/backend/apps/courses/serializers.py
+++ b/src/backend/apps/courses/serializers.py
@@ -15,10 +15,18 @@ class DersSerializer(serializers.ModelSerializer):
 class DonemDersiOkuSerializer(serializers.ModelSerializer):
     ders = DersSerializer(read_only=True)
     akademisyen_ad = serializers.SerializerMethodField()
+    ogrenci_sayisi = serializers.SerializerMethodField()
 
     class Meta:
         model = DonemDersi
-        fields = ["id", "ders", "akademisyen_ad", "yil", "donem", "kontenjan", "aktiflik_durumu"]
+        fields = ["id", "ders", "akademisyen_ad", "yil", "donem", "kontenjan", "ogrenci_sayisi", "aktiflik_durumu"]
 
     def get_akademisyen_ad(self, obj):
         return str(obj.akademisyen)
+
+    def get_ogrenci_sayisi(self, obj):
+        from apps.enrollments.models import DersKaydi
+        return DersKaydi.objects.filter(
+            donem_dersi=obj,
+            onay_durumu=DersKaydi.Durum.ONAYLANDI,
+        ).count()


### PR DESCRIPTION
## Sorun

Ders listesi endpoint'leri (`GET /api/courses/available/` ve `GET /api/academician/courses/`)
yalnızca toplam kontenjan bilgisini (`kontenjan`) döndürüyordu. Mevcut kayıt sayısı
response'a dahil edilmediği için frontend "0 Öğrenci / 100 Kontenjan" şeklinde
yanlış gösterim yapıyordu.

## Yapılan Değişiklik

`DonemDersiOkuSerializer`'a `ogrenci_sayisi` alanı eklendi. Bu alan ilgili derse
onaylanmış kayıt sayısını döndürüyor.

## Sonuç

Endpoint artık hem toplam kapasiteyi (`kontenjan`) hem de mevcut kayıt sayısını
(`ogrenci_sayisi`) döndürüyor. Frontend bu iki değeri kullanarak doğru doluluk
bilgisini gösterebilir.